### PR TITLE
Improve BigTIFF handling

### DIFF
--- a/butterfly_viewer/aux_splitview.py
+++ b/butterfly_viewer/aux_splitview.py
@@ -885,36 +885,13 @@ class SplitView(QtWidgets.QFrame):
                 
                 # 볼륨 이미지에서 원본 데이터 값 가져오기
                 try:
-                    from PIL import Image
-                    import numpy as np
-                    
-                    # 이미지 파일 열기
-                    with Image.open(volumetric_handler.filepath) as img:
-                        img.seek(current_slice)  # 현재 슬라이스로 이동
-                        
-                        # 이미지 범위 확인
-                        if 0 <= int_scene_x < img.width and 0 <= int_scene_y < img.height:
-                            # 이미지를 배열로 변환
-                            img_array = np.array(img)
-                            
-                            # 픽셀 값 가져오기
-                            if img.mode == 'L':  # 8비트 그레이스케일
-                                pixel_value = f"{img_array[int_scene_y, int_scene_x]}"
-                            elif img.mode == 'I':  # 32비트 정수
-                                pixel_value = f"{img_array[int_scene_y, int_scene_x]}"
-                            elif img.mode == 'F':  # 32비트 실수
-                                value = img_array[int_scene_y, int_scene_x]
-                                pixel_value = f"{value:.3f}"
-                            else:
-                                # RGB, RGBA 등 다른 이미지 모드 처리
-                                if img.mode == 'RGB':
-                                    r, g, b = img_array[int_scene_y, int_scene_x]
-                                    pixel_value = f"({r}, {g}, {b})"
-                                elif img.mode == 'RGBA':
-                                    r, g, b, a = img_array[int_scene_y, int_scene_x]
-                                    pixel_value = f"({r}, {g}, {b}, {a})"
-                                else:
-                                    pixel_value = f"{img_array[int_scene_y, int_scene_x]}"
+                    img_array = volumetric_handler.get_slice_array(current_slice)
+                    if img_array is not None and 0 <= int_scene_x < img_array.shape[1] and 0 <= int_scene_y < img_array.shape[0]:
+                        value = img_array[int_scene_y, int_scene_x]
+                        if volumetric_handler.is_float:
+                            pixel_value = f"{float(value):.3f}"
+                        else:
+                            pixel_value = f"{value}"
                 except Exception as e:
                     pixel_value = f"Error: {str(e)}"
         else:

--- a/butterfly_viewer/aux_volumetric.py
+++ b/butterfly_viewer/aux_volumetric.py
@@ -22,6 +22,8 @@ Supported formats:
 import os
 import numpy as np
 from PIL import Image
+import tifffile
+import imagecodecs
 from PyQt5 import QtCore, QtGui
 
 
@@ -56,6 +58,8 @@ class VolumetricImageHandler:
         self.data_range = (0, 255)  # Default for 8-bit data
         self.original_data_range = (0, 255)  # Store original range
         self.use_forced_range = False  # Flag to indicate if range is forced
+        self.use_tifffile = False  # Flag for using tifffile backend
+        self._memmap = None  # Optional memmapped array for direct access
         self._cached_slices = {}  # Dictionary to cache loaded slices
         self._analyze_file()
         
@@ -64,12 +68,41 @@ class VolumetricImageHandler:
         Also determines bit depth and data type, and analyzes all slices to find global min/max.
         """
         try:
+            with tifffile.TiffFile(self.filepath) as tif:
+                self.use_tifffile = True
+                series = tif.series[0]
+                dtype = series.dtype
+                self.bit_depth = dtype.itemsize * 8
+                self.is_float = np.issubdtype(dtype, np.floating)
+                try:
+                    mm = tifffile.memmap(self.filepath)
+                    self._memmap = mm
+                    self.total_slices = mm.shape[0] if mm.ndim > 2 else len(tif.pages)
+                    global_min = float(np.min(mm))
+                    global_max = float(np.max(mm))
+                except Exception:
+                    global_min, global_max = np.inf, -np.inf
+                    self.total_slices = len(tif.pages)
+                    for page in tif.pages:
+                        arr = page.asarray()
+                        slice_min = float(np.min(arr))
+                        slice_max = float(np.max(arr))
+                        global_min = min(global_min, slice_min)
+                        global_max = max(global_max, slice_max)
+                if global_min < global_max:
+                    self.original_data_range = (global_min, global_max)
+                    if not self.use_forced_range:
+                        self.data_range = self.original_data_range
+                self.current_slice = self.total_slices // 2
+                return
+        except Exception as e:
+            print(f"tifffile analysis failed: {e}")
+
+        try:
             with Image.open(self.filepath) as img:
-                # Allow 8-bit grayscale (L), 32-bit integer (I), 32-bit float (F), and all 16-bit integer variants
                 if img.mode not in ('L', 'I', 'F', 'I;16', 'I;16L', 'I;16B', 'I;16N'):
                     raise ValueError(f"Unsupported image mode: {img.mode}. Only single-channel images are supported.")
-                
-                # Determine bit depth and data type
+
                 if img.mode == 'L':
                     self.bit_depth = 8
                     self.is_float = False
@@ -77,50 +110,38 @@ class VolumetricImageHandler:
                 elif img.mode.startswith('I;16'):
                     self.bit_depth = 16
                     self.is_float = False
-                    # Initialize with 16-bit unsigned integer range
                     global_min, global_max = np.iinfo(np.uint16).max, np.iinfo(np.uint16).min
                 elif img.mode == 'I':
                     self.bit_depth = 32
                     self.is_float = False
-                    # Initialize with extreme values
                     global_min, global_max = np.iinfo(np.int32).max, np.iinfo(np.int32).min
                 elif img.mode == 'F':
                     self.bit_depth = 32
                     self.is_float = True
-                    # Initialize with extreme values
                     global_min, global_max = float('inf'), float('-inf')
-                
-                # Count total slices and find global min/max across all slices
+
                 self.total_slices = 0
-                
                 try:
-                    # First pass: count slices and compute global min/max
                     while True:
-                        # For non-8-bit images, analyze each slice to find min/max
                         if img.mode != 'L':
                             img_array = np.array(img)
-                            # For 16-bit images, ensure correct data type
                             if img.mode.startswith('I;16'):
                                 img_array = img_array.astype(np.uint16)
                             slice_min = np.min(img_array)
                             slice_max = np.max(img_array)
-                            
-                            # Update global min/max
                             global_min = min(global_min, slice_min)
                             global_max = max(global_max, slice_max)
-                        
+
                         self.total_slices += 1
                         img.seek(img.tell() + 1)
                 except EOFError:
                     pass
-                
-                # Store the original data range for all slices
+
                 if global_min < global_max:
                     self.original_data_range = (float(global_min), float(global_max))
                     if not self.use_forced_range:
                         self.data_range = self.original_data_range
-                
-                # Set current slice to middle by default
+
                 self.current_slice = self.total_slices // 2
         except Exception as e:
             print(f"Error analyzing volumetric file: {e}")
@@ -137,24 +158,27 @@ class VolumetricImageHandler:
             bool: True if the file is a single-channel multi-page TIFF with more than 1 slice, False otherwise
         """
         try:
-            # Check if file exists and is a TIFF
-            if not os.path.exists(filepath) or not filepath.lower().endswith(('.tif', '.tiff')):
+            if not os.path.exists(filepath) or not filepath.lower().endswith((".tif", ".tiff")):
                 return False
-                
-            # Check if it's a single-channel image
-            with Image.open(filepath) as img:
-                # Allow 8-bit grayscale (L), 32-bit integer (I), 32-bit float (F), and all 16-bit integer variants
-                if img.mode not in ('L', 'I', 'F', 'I;16', 'I;16L', 'I;16B', 'I;16N'):
+
+            with tifffile.TiffFile(filepath) as tif:
+                if len(tif.pages) <= 1:
                     return False
-                
-                # Check if it has multiple pages
-                try:
-                    img.seek(1)  # Try to move to the second frame
-                    return True  # If successful, it's multi-page
-                except EOFError:
-                    return False  # Only one page
+                if tif.pages[0].samples != 1:
+                    return False
+                return True
         except Exception:
-            return False
+            try:
+                with Image.open(filepath) as img:
+                    if img.mode not in ("L", "I", "F", "I;16", "I;16L", "I;16B", "I;16N"):
+                        return False
+                    try:
+                        img.seek(1)
+                        return True
+                    except EOFError:
+                        return False
+            except Exception:
+                return False
     
     def _normalize_image(self, img):
         """Normalize image data to 8-bit range for display.
@@ -209,27 +233,59 @@ class VolumetricImageHandler:
             
         # Load the slice
         try:
-            with Image.open(self.filepath) as img:
-                img.seek(slice_index)
-                
-                # Normalize image to 8-bit for display
-                normalized_img = self._normalize_image(img)
-                
-                # Convert PIL Image to QPixmap
-                data = normalized_img.tobytes("raw", "L")
-                qimage = QtGui.QImage(data, img.width, img.height, img.width, QtGui.QImage.Format_Grayscale8)
-                pixmap = QtGui.QPixmap.fromImage(qimage)
-                
-                # Cache the slice (limit cache to 10 slices to manage memory)
-                if len(self._cached_slices) > 10:
-                    # Remove least recently used slice (first key)
-                    oldest_key = next(iter(self._cached_slices))
-                    del self._cached_slices[oldest_key]
-                
-                self._cached_slices[slice_index] = pixmap
-                return pixmap
+            if self.use_tifffile:
+                if self._memmap is not None:
+                    arr = np.array(self._memmap[slice_index])
+                else:
+                    arr = tifffile.imread(self.filepath, key=slice_index)
+                img = Image.fromarray(arr)
+            else:
+                with Image.open(self.filepath) as im:
+                    im.seek(slice_index)
+                    img = im.copy()
+
+            normalized_img = self._normalize_image(img)
+
+            data = normalized_img.tobytes("raw", "L")
+            qimage = QtGui.QImage(
+                data,
+                normalized_img.width,
+                normalized_img.height,
+                normalized_img.width,
+                QtGui.QImage.Format_Grayscale8,
+            )
+            pixmap = QtGui.QPixmap.fromImage(qimage)
+
+            # Cache the slice (limit cache to 10 slices to manage memory)
+            if len(self._cached_slices) > 10:
+                oldest_key = next(iter(self._cached_slices))
+                del self._cached_slices[oldest_key]
+
+            self._cached_slices[slice_index] = pixmap
+            return pixmap
         except Exception as e:
             print(f"Error loading slice {slice_index}: {e}")
+            return None
+
+    def get_slice_array(self, slice_index=None):
+        """Get the raw numpy array for the specified slice."""
+        if slice_index is None:
+            slice_index = self.current_slice
+        if slice_index < 0 or slice_index >= self.total_slices:
+            return None
+        try:
+            if self.use_tifffile:
+                if self._memmap is not None:
+                    return np.array(self._memmap[slice_index])
+                return tifffile.imread(self.filepath, key=slice_index)
+            with Image.open(self.filepath) as im:
+                im.seek(slice_index)
+                arr = np.array(im)
+                if im.mode.startswith('I;16'):
+                    arr = arr.astype(np.uint16)
+                return arr
+        except Exception as e:
+            print(f"Error loading slice array {slice_index}: {e}")
             return None
     
     def set_current_slice(self, slice_index):

--- a/butterfly_viewer/butterfly_viewer.py
+++ b/butterfly_viewer/butterfly_viewer.py
@@ -2043,36 +2043,13 @@ class MultiViewMainWindow(QtWidgets.QMainWindow):
                     
                     # 볼륨 이미지에서 원본 데이터 값 가져오기
                     try:
-                        from PIL import Image
-                        import numpy as np
-                        
-                        # 이미지 파일 열기
-                        with Image.open(volumetric_handler.filepath) as img:
-                            img.seek(current_slice)  # 현재 슬라이스로 이동
-                            
-                            # 이미지 범위 확인
-                            if 0 <= int_scene_x < img.width and 0 <= int_scene_y < img.height:
-                                # 이미지를 배열로 변환
-                                img_array = np.array(img)
-                                
-                                # 픽셀 값 가져오기
-                                if img.mode == 'L':  # 8비트 그레이스케일
-                                    pixel_value = f"{img_array[int_scene_y, int_scene_x]}"
-                                elif img.mode == 'I':  # 32비트 정수
-                                    pixel_value = f"{img_array[int_scene_y, int_scene_x]}"
-                                elif img.mode == 'F':  # 32비트 실수
-                                    value = img_array[int_scene_y, int_scene_x]
-                                    pixel_value = f"{value:.3f}"
-                                else:
-                                    # RGB, RGBA 등 다른 이미지 모드 처리
-                                    if img.mode == 'RGB':
-                                        r, g, b = img_array[int_scene_y, int_scene_x]
-                                        pixel_value = f"({r}, {g}, {b})"
-                                    elif img.mode == 'RGBA':
-                                        r, g, b, a = img_array[int_scene_y, int_scene_x]
-                                        pixel_value = f"({r}, {g}, {b}, {a})"
-                                    else:
-                                        pixel_value = f"{img_array[int_scene_y, int_scene_x]}"
+                        img_array = volumetric_handler.get_slice_array(current_slice)
+                        if img_array is not None and 0 <= int_scene_x < img_array.shape[1] and 0 <= int_scene_y < img_array.shape[0]:
+                            value = img_array[int_scene_y, int_scene_x]
+                            if volumetric_handler.is_float:
+                                pixel_value = f"{float(value):.3f}"
+                            else:
+                                pixel_value = f"{value}"
                     except Exception as e:
                         pixel_value = f"Error: {str(e)}"
             else:
@@ -4285,53 +4262,31 @@ class MultiViewMainWindow(QtWidgets.QMainWindow):
         self.display_loading_grayout(True, "Processing 3D crop...")
         
         try:
-            # Import PIL here to avoid circular imports
-            from PIL import Image
-            import numpy as np
-            
-            # Extract the selected region from each slice
+            import tifffile
             crop_rect = itemRect.toRect()
-            
-            # Open the source file for reading
-            with Image.open(self.volumetric_handler.filepath) as source:
-                # Get the first image to determine shape, mode, etc.
-                source.seek(start_slice)
-                first_img = source.copy()
-                mode = first_img.mode
-                
-                # Crop the first image
-                cropped_first = first_img.crop((crop_rect.x(), crop_rect.y(), 
-                                               crop_rect.x() + crop_rect.width(), 
-                                               crop_rect.y() + crop_rect.height()))
-                
-                # Prepare list for all slices
-                cropped_slices = [cropped_first]
-                
-                # Process remaining slices
-                for i in range(start_slice + 1, end_slice + 1):
-                    # Update status with progress
-                    progress_pct = int((i - start_slice) / (end_slice - start_slice + 1) * 100)
-                    self.display_loading_grayout(True, f"Processing 3D crop... {progress_pct}%")
-                    
-                    # Get the slice
-                    source.seek(i)
-                    img = source.copy()
-                    
-                    # Crop the slice
-                    cropped = img.crop((crop_rect.x(), crop_rect.y(), 
-                                       crop_rect.x() + crop_rect.width(), 
-                                       crop_rect.y() + crop_rect.height()))
-                                       
-                    cropped_slices.append(cropped)
-                
-                # Save as multi-page TIFF
-                cropped_first.save(
-                    filepath,
-                    save_all=True,
-                    append_images=cropped_slices[1:],
-                    format='TIFF',
-                    compression='tiff_deflate'
-                )
+
+            cropped_arrays = []
+            for i in range(start_slice, end_slice + 1):
+                progress_pct = int((i - start_slice) / (end_slice - start_slice + 1) * 100)
+                self.display_loading_grayout(True, f"Processing 3D crop... {progress_pct}%")
+
+                arr = self.volumetric_handler.get_slice_array(i)
+                if arr is None:
+                    continue
+                cropped = arr[
+                    crop_rect.y() : crop_rect.y() + crop_rect.height(),
+                    crop_rect.x() : crop_rect.x() + crop_rect.width(),
+                ]
+                cropped_arrays.append(cropped)
+
+            if not cropped_arrays:
+                raise RuntimeError("No slices cropped")
+
+            tifffile.imwrite(
+                filepath,
+                np.stack(cropped_arrays),
+                compression="deflate",
+            )
                 
             # Show success message
             self.display_loading_grayout(True, f"3D crop saved successfully: {filepath}")
@@ -4983,13 +4938,10 @@ class MultiViewMainWindow(QtWidgets.QMainWindow):
             if hasattr(child, 'is_volumetric') and child.is_volumetric:
                 # For volumetric data
                 try:
-                    from PIL import Image
-                    import numpy as np
-                    
                     current_slice = child.current_slice
-                    with Image.open(child.volumetric_handler.filepath) as img:
-                        img.seek(current_slice)
-                        image_data = np.array(img)
+                    image_data = child.volumetric_handler.get_slice_array(current_slice)
+                    if image_data is None:
+                        raise RuntimeError("Slice load failed")
                 except Exception as e:
                     print(f"Error loading volumetric data: {str(e)}")
                     continue

--- a/environment.yml
+++ b/environment.yml
@@ -32,6 +32,8 @@ dependencies:
   - matplotlib=3.3.4
   - pandas=1.1.5
   - openpyxl=3.0.7
+  - tifffile=2021.4.8
+  - imagecodecs=2021.11.20
   - pip:
     - pyinstaller==4.3
     - packaging==20.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,8 @@ matplotlib==3.3.4
 pandas==1.1.5
 openpyxl==3.0.10
 packaging==20.9
+tifffile==2021.4.8
+imagecodecs==2021.11.20
 
 # Python certificates
 certifi==2021.5.30


### PR DESCRIPTION
## Summary
- use tifffile memmap for volumetric analysis
- cache memmapped array for slice access
- switch 3D crop to tifffile.imwrite
- add imagecodecs dependency

## Testing
- `python -m py_compile butterfly_viewer/aux_volumetric.py butterfly_viewer/aux_splitview.py butterfly_viewer/aux_profile.py butterfly_viewer/butterfly_viewer.py tools/volumetric_tester.py`

------
https://chatgpt.com/codex/tasks/task_e_6836942d843c8333803db55435c9ad02